### PR TITLE
Add shared_ptr aliases

### DIFF
--- a/rmf_battery/include/rmf_battery/DevicePowerSink.hpp
+++ b/rmf_battery/include/rmf_battery/DevicePowerSink.hpp
@@ -18,8 +18,9 @@
 #ifndef RMF_BATTERY__DEVICEPOWERSINK_HPP
 #define RMF_BATTERY__DEVICEPOWERSINK_HPP
 
-namespace rmf_battery {
+#include <memory>
 
+namespace rmf_battery {
 
 //==============================================================================
 class DevicePowerSink
@@ -39,6 +40,9 @@ public:
 
   virtual ~DevicePowerSink() = default;
 };
+
+using DevicePowerSinkPtr = std::shared_ptr<DevicePowerSink>;
+using ConstDevicePowerSinkPtr = std::shared_ptr<const DevicePowerSink>;
 
 } // namespace rmf_battery
 

--- a/rmf_battery/include/rmf_battery/MotionPowerSink.hpp
+++ b/rmf_battery/include/rmf_battery/MotionPowerSink.hpp
@@ -22,7 +22,6 @@
 
 namespace rmf_battery {
 
-
 //==============================================================================
 class MotionPowerSink
 {
@@ -41,6 +40,9 @@ public:
 
   virtual ~MotionPowerSink() = default;
 };
+
+using MotionPowerSinkPtr = std::shared_ptr<MotionPowerSink>;
+using ConstMotionPowerSinkPtr = std::shared_ptr<const MotionPowerSink>;
 
 } // namespace rmf_battery
 


### PR DESCRIPTION
Since downstream libraries will generally be using these interfaces as `std::shared_ptr`s, let's add some aliases for that to the API.