### PR TITLE
Removed push trigger for tsan workflow

### DIFF
--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -1,6 +1,5 @@
 name: tsan
 on: 
-  push:
   pull_request:
   schedule:
     - cron: '7 0 * * *'


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## CI/Workflow

* Removed push trigger for `tsan` workflow