### PR TITLE
Remove CMake export(PACKAGE ...) invocation

### DIFF
--- a/rmf_battery/CMakeLists.txt
+++ b/rmf_battery/CMakeLists.txt
@@ -134,5 +134,3 @@ export(
   FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_battery-targets.cmake
   NAMESPACE rmf_battery::
 )
-
-export(PACKAGE rmf_battery)


### PR DESCRIPTION
The CMake user package registry can cause unexpected behavior if people aren't accustomed to it. This PR removes the `export(PACKAGE ...)` invocation that adds to the user package registry in `~/.cmake/packages` during the `colcon` build/install process.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>