### PR TITLE
Update CI to Humble

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -1,6 +1,5 @@
 name: asan
 on:
-on:
   pull_request:
   push:
     branches: [ main ]

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -1,23 +1,35 @@
 name: asan
-on: 
-  push:
+on:
+on:
   pull_request:
+  push:
+    branches: [ main ]
   schedule:
     - cron: '7 0 * * *'
+defaults:
+  run:
+    shell: bash
 
 jobs:
   asan:
     name: asan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.3
         with:
-          required-ros-distributions: foxy
+          required-ros-distributions: humble
+      - name: install_clang
+        run: sudo apt update && sudo apt install -y clang clang-tools lld
       - name: build_and_test
         uses: ros-tooling/action-ros-ci@v0.2
+        env:
+          CC: clang
+          CXX: clang++
         with:
-          target-ros2-distro: foxy
+          target-ros2-distro: humble
           # build all packages listed in the meta package
           package-name: |
             rmf_battery
@@ -26,7 +38,7 @@ jobs:
           colcon-defaults: |
             {
               "build": {
-                "mixin": ["asan-gcc"],
+                "mixin": ["asan-gcc", "lld"],
                 "cmake-args": ["-DCMAKE_BUILD_TYPE=Debug"]
               }
             }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,23 +1,34 @@
 name: build
-on: 
-  push:
+on:
   pull_request:
+  push:
+    branches: [ main ]
   schedule:
     - cron: '12 0 * * *'
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build_and_test:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.3
         with:
-          required-ros-distributions: foxy
+          required-ros-distributions: humble
+      - name: install_clang
+        run: sudo apt update && sudo apt install -y clang clang-tools lld
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
+        env:
+          CC: clang
+          CXX: clang++
         with:
-          target-ros2-distro: foxy
+          target-ros2-distro: humble
           # build all packages listed in the meta package
           package-name: |
             rmf_battery
@@ -26,7 +37,7 @@ jobs:
           colcon-defaults: |
             {
               "build": {
-                "mixin": ["coverage-gcc"]
+                "mixin": ["coverage-gcc","lld"]
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
@@ -36,4 +47,3 @@ jobs:
           files: ros_ws/lcov/total_coverage.info
           flags: tests
           name: lean_and_mean_codecov_bot
-

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -19,5 +19,6 @@ jobs:
         uses: actions/checkout@v2
       - name: uncrustify
         run: |
+          sudo apt update && sudo apt install wget
           wget https://raw.githubusercontent.com/open-rmf/rmf_utils/main/rmf_utils/test/format/rmf_code_style.cfg
           /ros_entrypoint.sh ament_uncrustify -c rmf_code_style.cfg rmf_battery --language C++

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,0 +1,23 @@
+name: style
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+defaults:
+  run:
+    shell: bash
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker_image: ['ros:humble-ros-base']
+    container:
+      image: ${{ matrix.docker_image }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: uncrustify
+        run: |
+          wget https://raw.githubusercontent.com/open-rmf/rmf_utils/main/rmf_utils/test/format/rmf_code_style.cfg
+          /ros_entrypoint.sh ament_uncrustify -c rmf_code_style.cfg rmf_battery --language C++

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -1,5 +1,5 @@
 name: tsan
-on: 
+on:
   pull_request:
   schedule:
     - cron: '7 0 * * *'
@@ -7,12 +7,16 @@ on:
 jobs:
   tsan:
     name: tsan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.3
         with:
-          required-ros-distributions: foxy
+          required-ros-distributions: humble
+      - name: install_clang
+        run: sudo apt update && sudo apt install -y clang clang-tools lld
       - name: tsan_build_test
         uses: ros-tooling/action-ros-ci@v0.2
         id: tsan_build_test
@@ -20,16 +24,16 @@ jobs:
           CC: clang
           CXX: clang++
         with:
-          target-ros2-distro: foxy
+          target-ros2-distro: humble
           # build all packages listed in the meta package
           package-name: |
-            rmf_battery 
+            rmf_battery
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
           colcon-defaults: |
             {
               "build": {
-                "mixin": ["tsan"],
+                "mixin": ["tsan", "lld"],
                 "cmake-args": ["-DCMAKE_BUILD_TYPE=Debug"]
               }
             }
@@ -40,4 +44,3 @@ jobs:
           name: colcon-test-logs
           path: ${{ steps.tsan_build_test.outputs.ros-workspace-directory-name }}/log
         if: always()
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # rmf\_battery
 
 ![](https://github.com/open-rmf/rmf_battery/workflows/build/badge.svg)
+![](https://github.com/open-rmf/rmf_battery/workflows/asan/badge.svg)
+![](https://github.com/open-rmf/rmf_battery/workflows/tsan/badge.svg)
+![](https://github.com/open-rmf/rmf_battery/workflows/style/badge.svg)
 [![codecov](https://codecov.io/gh/open-rmf/rmf_battery/branch/main/graph/badge.svg)](https://codecov.io/gh/open-rmf/rmf_battery)
 
-The `rmf_battery` package provides modelling of robot battery life.
+The `rmf_battery` package provides APIs for modelling a robot's battery life.


### PR DESCRIPTION
* Updated build asan and tsan CI to run on Ubuntu 22.04 and humble
* Added style CI

> Note: Galactic only developments can be merged to `galactic-devel` branch