### PR TITLE
Add buildtool_depend on cmake

### DIFF
--- a/rmf_battery/package.xml
+++ b/rmf_battery/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <build_depend>eigen</build_depend>


### PR DESCRIPTION
## Bug fix

### Fixed bug

Even though this is considered a CMake package, it should declare a dependency on the cmake build tool. This is not currently a problem on the buildfarm because our deb builds currently build tests as well, and one of the test dependencies is bringing the cmake dependency indirectly. We'd like to disable tests in deb builds, so to prevent that change from breaking this package, we should fix the bug.

This change should be backported to the `humble` branch and released as well.

### Fix applied

Added the missing buildtool dependency to the package manifest.