### PR TITLE
Bump 0.2.0 and switch to rst changelogs

### DIFF
--- a/rmf_battery/CHANGELOG.rst
+++ b/rmf_battery/CHANGELOG.rst
@@ -1,21 +1,22 @@
-## Changelog for package rmf_battery
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rmf_battery
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 0.1.4 (2023-04-15)
------------
-* Port changes from main into rolling [#34](https://github.com/open-rmf/rmf_battery/issues/34)
-* Reusable ci [#28](https://github.com/open-rmf/rmf_battery/issues/28)
-* Add buildtool_depend on cmake [#31](https://github.com/open-rmf/rmf_battery/issues/31)
-* Add back missing ament index path exporting in CMakeLists [#33](https://github.com/open-rmf/rmf_battery/issues/33)
+------------------
+* Reusable ci (`#28 <https://github.com/open-rmf/rmf_battery/pull/28>`_)
+* Add buildtool_depend on cmake (`#31 <https://github.com/open-rmf/rmf_battery/pull/31>`_)
+* Add back missing ament index path exporting in CMakeLists (`#33 <https://github.com/open-rmf/rmf_battery/pull/33>`_)
 * Contributors: Chen Bainian, Esteban Martinena Guerrero, Scott K Logan, Yadunund
 
 0.1.3 (2022-02-14)
 ------------------
-* Use ament_cmake_uncrustify [#20](https://github.com/open-rmf/rmf_battery/pull/20)
-* Prepend package path to AMENT_PREFIX_PATH [#22](https://github.com/open-rmf/rmf_battery/pull/22)
+* Use ament_cmake_uncrustify (`#20 <https://github.com/open-rmf/rmf_battery/pull/20>`_)
+* Prepend package path to AMENT_PREFIX_PATH (`#22 <https://github.com/open-rmf/rmf_battery/pull/22>`_)
 
 0.1.2 (2021-10-27)
 ------------------
-* Using eigen3_cmake_module to fix RHEL build [#16](https://github.com/open-rmf/rmf_battery/commit/7e1a4e73135963df2542e40913aa50ae79266fb3)
+* Using eigen3_cmake_module to fix RHEL build (`#16 <https://github.com/open-rmf/rmf_battery/commit/7e1a4e73135963df2542e40913aa50ae79266fb3>`_)
 
 0.1.1 (2021-09-08)
 ------------------

--- a/rmf_battery/CHANGELOG.rst
+++ b/rmf_battery/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmf_battery
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Switch to rst changelogs
+* Contributors: Yadunund
+
 0.1.4 (2023-04-15)
 ------------------
 * Reusable ci (`#28 <https://github.com/open-rmf/rmf_battery/pull/28>`_)

--- a/rmf_battery/CHANGELOG.rst
+++ b/rmf_battery/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmf_battery
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.2.0 (2023-06-06)
+------------------
 * Switch to rst changelogs
 * Contributors: Yadunund
 

--- a/rmf_battery/package.xml
+++ b/rmf_battery/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_battery</name>
-  <version>0.1.4</version>
+  <version>0.2.0</version>
   <description>Package for modelling battery life of robots</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>


### PR DESCRIPTION
This is to align with [REP 132](https://www.ros.org/reps/rep-0132.html) and will greatly improve the ease of updating changelogs in the future as they will be auto-populated when running [catkin_generate_changelog](https://docs.ros.org/en/rolling/How-To-Guides/Releasing/Subsequent-Releases.html#updating-changelog)

> Note: The `CHANGELOG.rst` was autogenerated from the existing `CHANGELOG.md` using [catkin_md2rst_changelog](https://github.com/Yadunund/catkin_pkg/blob/yadu/md2rst/src/catkin_pkg/cli/md2rst_changelog.py)