### PR TITLE
Bump main to match rolling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,49 +1,15 @@
 name: build
 on:
   pull_request:
-  push:
-    branches: [ main ]
   schedule:
     - cron: '12 0 * * *'
-defaults:
-  run:
-    shell: bash
+  workflow_dispatch:
 
 jobs:
   build_and_test:
-    name: Build and test
-    runs-on: ubuntu-latest
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
-    steps:
-      - name: deps
-        uses: ros-tooling/setup-ros@v0.3
-        with:
-          required-ros-distributions: humble
-      - name: install_clang
-        run: sudo apt update && sudo apt install -y clang clang-tools lld
-      - name: build
-        uses: ros-tooling/action-ros-ci@v0.2
-        env:
-          CC: clang
-          CXX: clang++
-        with:
-          target-ros2-distro: humble
-          # build all packages listed in the meta package
-          package-name: |
-            rmf_battery
-          vcs-repo-file-url: |
-            https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
-          colcon-defaults: |
-            {
-              "build": {
-                "mixin": ["coverage-gcc","lld"]
-              }
-            }
-          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          files: ros_ws/lcov/total_coverage.info
-          flags: tests
-          name: lean_and_mean_codecov_bot
+    name: rmf_battery
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    with:
+      # NOTE: Avoid adding comments in the packages lines, this can break some of the called scripts in github actions
+      packages: |
+        rmf_battery

--- a/rmf_battery/CHANGELOG.md
+++ b/rmf_battery/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog for package rmf_battery
 
+0.1.4 (2023-04-15)
+-----------
+* Port changes from main into rolling [#34](https://github.com/open-rmf/rmf_battery/issues/34)
+* Reusable ci [#28](https://github.com/open-rmf/rmf_battery/issues/28)
+* Add buildtool_depend on cmake [#31](https://github.com/open-rmf/rmf_battery/issues/31)
+* Add back missing ament index path exporting in CMakeLists [#33](https://github.com/open-rmf/rmf_battery/issues/33)
+* Contributors: Chen Bainian, Esteban Martinena Guerrero, Scott K Logan, Yadunund
+
 0.1.3 (2022-02-14)
 ------------------
 * Use ament_cmake_uncrustify [#20](https://github.com/open-rmf/rmf_battery/pull/20)

--- a/rmf_battery/CMakeLists.txt
+++ b/rmf_battery/CMakeLists.txt
@@ -134,3 +134,10 @@ export(
   FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_battery-targets.cmake
   NAMESPACE rmf_battery::
 )
+
+# Export ament index path
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv DESTINATION share/${PROJECT_NAME}/hook)

--- a/rmf_battery/CMakeLists.txt
+++ b/rmf_battery/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(rmf_battery VERSION 0.1.3)
+project(rmf_battery VERSION 0.1.4)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 

--- a/rmf_battery/package.xml
+++ b/rmf_battery/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_battery</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>Package for modelling battery life of robots</description>
-  <maintainer email="yadunund@openrobotics.org">yadu</maintainer>
+  <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache License 2.0</license>
 

--- a/rmf_battery/package.xml
+++ b/rmf_battery/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
   <license>Apache License 2.0</license>
 
+  <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <build_depend>eigen</build_depend>


### PR DESCRIPTION
We should merge commit this and not squash merge to ensure the commit with the `0.1.4` tag is also present on `main` branch.